### PR TITLE
Style the horizontal radio group

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -29,3 +29,37 @@ input {
     background-color: #f9ecea;
   }
 }
+
+.radio-group-horizontal {
+  width: 80%;
+  div {
+    border: 1px solid $forsa-aqua;
+    border-radius: $form-button-radius;
+
+    label {
+      color: $white;
+      background-color: lighten($forsa-aqua, 10%);
+      margin: 0;
+      text-align: center;
+      width: 25%;
+      padding: 0.5rem;
+      font-family: $body-font-family;
+      border-right: 1px solid $forsa-aqua;
+    }
+
+    label:last-child {
+      border-right: 0;
+    }
+
+    input[type=radio] {
+      opacity: 0;
+      position: fixed;
+      width: 0;
+    }
+
+    input[type=radio]:checked + label {
+      background-color: $forsa-aqua;
+      font-family: $body-font-family-bold;
+    }
+  }
+}

--- a/app/views/membership_applications/steps/work-and-pay.html.erb
+++ b/app/views/membership_applications/steps/work-and-pay.html.erb
@@ -24,9 +24,11 @@
     <%= help_for :pay_rate %>
     <%= f.text_field :pay_rate %>
 
-    <fieldset>
+    <fieldset class="radio-group-horizontal">
       <label class="side-note">Every:</label>
-      <%= f.collection_radio_buttons :pay_unit, MembershipApplication::PAY_UNIT, :to_s, :capitalize %>
+      <div>
+        <%= f.collection_radio_buttons :pay_unit, MembershipApplication::PAY_UNIT, :to_s, :capitalize %>
+      </div>
     </fieldset>
 
     <%= f.submit 'Next' %>


### PR DESCRIPTION
Hide the radio buttons as 0-opacity to keep them selectable. Use
fieldset with class .radio-group-horizontal for the outer semantics,
and an inner div to hold the actual buttons.