### PR TITLE
Ask the server for rates when we have fields

### DIFF
--- a/app/javascript/packs/work_and_pay.js
+++ b/app/javascript/packs/work_and_pay.js
@@ -48,10 +48,17 @@ function monthlyEstimateArrived(value) {
   showSpinner(false)
 }
 
+function weHaveEnoughFields() {
+  return (payValue('pay_rate') && (payUnitValue() === 'hour') && payValue('hours_per_week')) ||
+    ((payValue('pay_rate')) && payUnitValue());
+}
+
 function estimateInputChanged(interval = 1500) {
-  clearTimeout(timer)
-  showSpinner(true)
-  timer = setTimeout(getMonthlyEstimate, interval)
+  if(weHaveEnoughFields()) {
+    clearTimeout(timer)
+    showSpinner(true)
+    timer = setTimeout(getMonthlyEstimate, interval)
+  }
 }
 
 $(document).on('turbolinks:load', function() {


### PR DESCRIPTION
We were asking all the time; now we only ask if we have pay_rate
and pay_unit, or in the case of pay_unit == 'hour', also hours_per_week.