### PR TITLE
Remove email uniqueness validation

### DIFF
--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -4,7 +4,6 @@ class MembershipApplication < ApplicationRecord
     with: /\A.+@.+\..+\z/i,
     message: 'Enter a valid email address'
   }
-  validates :email, uniqueness: true, on: :create
 
   # Step 1: About you
   GENDER = %w[male female non-binary other]


### PR DESCRIPTION
Could be used to enumerate members. Accept duplication is a necessary
cost to avoiding abuse.