### PR TITLE
85 record estimate as it was taken

### DIFF
--- a/app/javascript/packs/work_and_pay.js
+++ b/app/javascript/packs/work_and_pay.js
@@ -50,6 +50,7 @@ function monthlyEstimateErrored(error) {
 
 function monthlyEstimateArrived(value) {
   $('#monthly-estimate-value').text(value)
+  $('#membership_application_applicant_saw_monthly_estimate').val(value)
   $('.monthly-estimate').removeClass('hide')
   showSpinner(false)
 }

--- a/app/models/membership_application/steps.rb
+++ b/app/models/membership_application/steps.rb
@@ -7,7 +7,7 @@ class MembershipApplication
       'contact-details'        => [:email, :phone_number, :home_address],
       'your-work'              => [:job_title, :employer, :work_address, :payroll_number,
                                    :school_roll_number, :technical_grade],
-      'your-subscription-rate' => [:pay_rate, :pay_unit, :hours_per_week],
+      'your-subscription-rate' => [:pay_rate, :pay_unit, :hours_per_week, :applicant_saw_monthly_estimate],
       'declaration'            => [:declaration]
     }]
 

--- a/app/views/membership_applications/steps/your-subscription-rate.erb
+++ b/app/views/membership_applications/steps/your-subscription-rate.erb
@@ -30,6 +30,7 @@
       <label>
         Based on your salary, your monthly payment will be
         €<span id="monthly-estimate-value">#NOVALUE</span>
+        <%= f.hidden_field :applicant_saw_monthly_estimate %>
       </label>
 
       <div class="help-text">

--- a/db/migrate/20200417124144_add_applicant_saw_monthly_estimate.rb
+++ b/db/migrate/20200417124144_add_applicant_saw_monthly_estimate.rb
@@ -1,0 +1,5 @@
+class AddApplicantSawMonthlyEstimate < ActiveRecord::Migration[6.0]
+  def change
+    add_column :membership_applications, :applicant_saw_monthly_estimate, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_16_113640) do
+ActiveRecord::Schema.define(version: 2020_04_17_124144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2020_04_16_113640) do
     t.string "gender"
     t.string "school_roll_number"
     t.string "technical_grade"
+    t.decimal "applicant_saw_monthly_estimate"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
When the applicant sees a monthly estimate, a hidden field is updated with the same value they saw. This goes to the `applicant_saw_monthly_estimate` field. 

If that remains `nil`, it indicates that the applicant never saw an estimate, though a calculation can still be made via the usual combination of `pay_unit`, `pay_rate` and `hours_per_week`