### PR TITLE
Make a date range search

### DIFF
--- a/app/controllers/admin/membership_applications_controller.rb
+++ b/app/controllers/admin/membership_applications_controller.rb
@@ -2,9 +2,24 @@ class Admin::MembershipApplicationsController < ApplicationController
   def index
     @membership_applications = MembershipApplication.signed
 
+    @date_range_params = date_range_params
+    @range_query = View::DateRangeQuery.new(@date_range_params)
+    if @range_query.present? && @range_query.valid?
+      @membership_applications = @membership_applications.merge(MembershipApplication.where(updated_at: @range_query.range))
+    end
+
     respond_to do |format|
       format.html { render }
-      format.json { render json: @membership_applications }
+      format.json do
+        render status: 400, json: { errors: @range_query.errors } and return unless @range_query.valid?
+        render json: @membership_applications
+      end
     end
+  end
+
+  private
+
+  def date_range_params
+    params.permit(:from_date, :to_date)
   end
 end

--- a/app/models/view/date_range_query.rb
+++ b/app/models/view/date_range_query.rb
@@ -1,0 +1,57 @@
+module View
+  class DateRangeQuery
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    class DateValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        time_or_date = DateRangeQuery.try_parse_date(value)
+        record.errors.add attribute, 'is not a date or date/time' if time_or_date.nil?
+      end
+    end
+
+    # Attrs as strings so no coercion
+    attribute :from_date, :string
+    attribute :to_date, :string
+
+    validates :from_date, date: true, allow_blank: true
+    validates :to_date, date: true, allow_blank: true
+
+    validate :from_date_less_than_to_date, if: -> { from_date.present? && to_date.present? }
+
+    def initialize(params)
+      @params = params
+      super(params)
+    end
+
+    def inspect
+      "from_date: #{from_date.class}: #{from_date}, to_date: #{to_date.class}: #{to_date}"
+    end
+
+    def empty?
+      from_date.blank? && to_date.blank?
+    end
+
+    def present?
+      !empty?
+    end
+
+    def range
+      DateRangeQuery.try_parse_date(from_date)..DateRangeQuery.try_parse_date(to_date)
+    end
+
+    def scope
+      MembershipApplication.where(updated_at: range)
+    end
+
+    def self.try_parse_date(value)
+      (Time.zone.parse(value) rescue nil) || (Date.parse(value) rescue nil)
+    end
+
+    private
+
+    def from_date_less_than_to_date
+      errors[:from_date] << 'from date is after to date' if from_date > to_date
+    end
+  end
+end

--- a/app/views/admin/membership_applications/index.html.erb
+++ b/app/views/admin/membership_applications/index.html.erb
@@ -6,6 +6,31 @@
   Signed membership applications
 </h1>
 
+<%= form_with scope: nil, method: :get, local: true do |f| %>
+  <%# We want to avoid the standard verbose naming convention view_date_range_query[from_date] %>
+  <%# (because that's terrible for hacking the API URL together with %5B for [ everywhere) %>
+  <%# So we use scope: nil to avoid the namespace. %>
+  <%# But then we put object back on afterwards, so we can get values and use form_field_errors %>
+  <% f.object = @range_query %>
+  <fieldset>
+    <div class="grid-x grid-margin-x">
+      <div class="cell small-6">
+        <%= f.label :from_date %>
+        <%= form_field_errors(f, :from_date) %>
+        <%= help_for :date_search_field %>
+        <%= f.text_field :from_date, value: params[:from_date] %>
+      </div>
+      <div class="cell small-6">
+        <%= f.label :to_date %>
+        <%= form_field_errors(f, :to_date) %>
+        <%= help_for :date_search_field %>
+        <%= f.text_field :to_date, value: params[:to_date]  %>
+      </div>
+    </div>
+    <%= f.submit 'Search', name: nil %>
+  </fieldset>
+<% end %>
+
 <table class="hover">
   <thead>
   <tr>
@@ -26,6 +51,12 @@
 </table>
 
 <%=
-  link_to 'Get the JSON', admin_membership_applications_path(format: :json),
+  link_to(
+    'Get the JSON',
+    admin_membership_applications_path(
+      @date_range_params.merge(format: :json)
+    ),
     class: 'button float-right'
+  )
 %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,9 @@ en:
         declaration: 'This must be "%{full_name}"'
         hours_per_week: 'Take the average over the last month.'
         school_roll_number: 'Five digits followed by a letter – found on your payslip'
+        # Shouldn't be here because isn't a membership application field but are for
+        # date search/not refactoring help_for convenience
+        date_search_field: 'e.g. 2020-04-19, 2020-04-19 23:59:59'
     help_dropdown:
       membership_application:
         email:

--- a/spec/models/view/date_range_query_spec.rb
+++ b/spec/models/view/date_range_query_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe View::DateRangeQuery do
+  subject(:query) { View::DateRangeQuery.new(params) }
+
+  context 'there are no params' do
+    let(:params) { {} }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to be_empty }
+  end
+
+  context 'one of the params is bad' do
+    let(:params) { { from_date: 'not_a_date', to_date: '2020-04-21' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'both the dates are fine' do
+    let(:params) { { from_date: '2020-04-20', to_date: '2020-04-21' } }
+
+    it { is_expected.to be_valid }
+
+    it do
+      expect(query.range).to eql(Time.zone.parse('2020-04-20')..Time.zone.parse('2020-04-21'))
+    end
+  end
+
+  context 'the to date is before the from date' do
+    let(:params) { { from_date: '2020-04-22', to_date: '2020-04-21' } }
+
+    it 'has the error' do
+      aggregate_failures do
+        expect(query).not_to be_valid
+        expect(query.errors[:from_date]).to eql(['from date is after to date'])
+      end
+    end
+  end
+end

--- a/spec/requests/admin/membership_applications_request_spec.rb
+++ b/spec/requests/admin/membership_applications_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe '/admin/membership-applications as JSON', type: :request do
   include TokenAuthenticationHelpers
 
-  let(:params)  { { } }
+  let(:params)  { {} }
   let(:headers) { { 'Accept' => 'application/json' } }
 
   subject(:json) { JSON.parse(response.body) }
@@ -22,13 +22,16 @@ RSpec.describe '/admin/membership-applications as JSON', type: :request do
   end
 
   context 'credentials are supplied so we can get by date' do
+    let(:old_date) { '2020-04-14 01:00:59' }
+    let(:new_date) { '2020-04-15' }
+
     let!(:signed_applications) do
-      create_list :membership_application, 2, :step_declaration, employer: 'Lastweek', updated_at: 1.week.ago
-      create_list :membership_application, 2, :step_declaration, employer: 'Today', updated_at: Date.today
+      create_list :membership_application, 2, :step_declaration, employer: 'Yesterday', updated_at: old_date
+      create_list :membership_application, 2, :step_declaration, employer: 'Today', updated_at: new_date
     end
     let!(:incomplete_applications) do
-      create_list :membership_application, 2, :step_about_you, employer: 'Lastweek', updated_at: 1.week.ago
-      create_list :membership_application, 2, :step_about_you, employer: 'Today', updated_at: Date.today
+      create_list :membership_application, 2, :step_about_you, employer: 'Yesterday', updated_at: old_date
+      create_list :membership_application, 2, :step_about_you, employer: 'Today', updated_at: new_date
     end
 
     before do
@@ -42,8 +45,25 @@ RSpec.describe '/admin/membership-applications as JSON', type: :request do
       end
     end
 
-    context 'date params are given' do
-      it 'restricts applications to those in date range'
+    context 'invalid date params are given' do
+      let(:params) { { from_date: '2021-04-14', to_date: '2020-04-14' } }
+
+      it '400s' do
+        aggregate_failures do
+          expect(response.status).to eql(400)
+          expect(json).to eql('errors' => { 'from_date' => ['from date is after to date'] })
+        end
+      end
+    end
+
+    context 'valid date params are given' do
+      let(:params) { { from_date: '2020-04-14', to_date: '2020-04-14 23:59:59' } }
+
+      it 'restricts applications to those in date range' do
+        expect(MembershipApplication.signed.count).to eql(4)
+        expect(json.length).to eql(2)
+        expect(json.map { |item| item['employer'] }).to all(eql('Yesterday'))
+      end
     end
   end
 end


### PR DESCRIPTION
Available from both HTML and JSON. Use a view model
View::DateRangeQuery to validate the parameters, and render errors
as JSON when necessary.

It's a bit hacky on the form side, using a combination of

form_with scope: nil and an `f.object = @date_range_query` to get
our field-with-errors implementation working.

Also we're shoehorning some help text for the search in with
membership_application in en.yml. It doesn't really belong there but
we don't have to refactor help_for and its template to get it.