### PR TITLE
Lose some JS weight

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,12 +7,15 @@ require("@rails/ujs").start()
 require("jquery")
 require("turbolinks").start()
 
-import {Foundation} from 'foundation-sites';
+import {Foundation} from 'foundation-sites/js/foundation.core';
+import {Dropdown} from 'foundation-sites/js/foundation.dropdown';
 // IE11 support - gets use 'fetch' which uses Promise
 import 'promise-polyfill/src/polyfill'
 import 'whatwg-fetch'
 
 Foundation.addToJquery($)
+Foundation.plugin(Dropdown, 'Dropdown')
+$(document).foundation()
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)


### PR DESCRIPTION
Stop importing all of foundation-sites; our Webpack config is not tree-
shaking the remaining components from the bundle, resulting in a large
file size.

Use the approach outlined in

https://github.com/foundation/foundation-sites/issues/11401#issuecomment-521710616

to import only Dropdown