### PR TITLE
Reword the completion page

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -147,7 +147,7 @@ $header-font-style: normal;
 $font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
 $header-color: inherit;
 $header-lineheight: 1.4;
-$header-margin-bottom: 0.5rem;
+$header-margin-bottom: 1rem;
 $header-styles: (
   small: (
     'h1': ('font-size': 24),

--- a/app/views/membership_applications/completed.html.erb
+++ b/app/views/membership_applications/completed.html.erb
@@ -1,8 +1,11 @@
-<h1>Application complete - THANK YOU!</h1>
+<h1>
+  Thank you.<br />
+  Welcome to Fórsa!
+</h1>
 
 <% if @membership_application.answered_post_join? %>
   <div class="callout secondary">
-    <h3><%= t('thanks_on_completion') %></h3>
+    <p class="h4"><strong><%= t('thanks_on_completion') %></strong></p>
   </div>
 <% else %>
   <h3>Your application is complete, but we have two final questions for you:</h3>
@@ -28,16 +31,14 @@
   </div>
 <% end %>
 
-<h2>Here’s what happens next…</h2>
+<h2 class="h4">Here’s what will happen next.</h2>
 
-<ol>
-  <li>You’ll get an email from us confirming that we have received your application and asking you to verify it by clicking on a link (this may or maynot be necessary but it might provide an additional protection for GDPR)</li>
-  <li>We will notify your branch of your application and we will ask your employer to deduct your union subscriptions</li>
-  <li>You’ll get an email informing you of your branch details and how to access additional union benefits</li>
-  <li>You’ll receive your membership card with your unique membership number</li>
-  <li>You now have a voice in the workplace, and benefit from the collective strength of being one of Fórsa’s 80,000+ members*</li>
-</ol>
+<ul class="no-bullet">
+  <li><p><strong>Now:</strong> You’ll get an email from us confirming your membership details.</p></li>
+  <li><p><strong>This month:</strong> You’ll be assigned to a branch and will receive your membership card and pack.</p></li>
+  <li><p><strong>From now on:</strong> You’re protected at work and will benefit from collectively negotiated improvements to pay and conditions.</p></li>
+</ul>
 
-<p>Thank you for joining us.</p>
+<p class="h4"><strong>You’re one of over 80,000 Fórsa members. Thanks for joining us.</strong></p>
 
 <p class="side-note">(*Subject to final processing and authorisation)<p>

--- a/spec/features/a_new_member_joins_spec.rb
+++ b/spec/features/a_new_member_joins_spec.rb
@@ -71,7 +71,7 @@ feature 'A new member joins' do
     end
 
     # Then I see a temporary finishing page
-    expect(page).to have_content 'Application complete'
+    expect(page).to have_content 'Welcome to Fórsa!'
 
     # When I fill in the extra questions
     fill_in 'Have you previously been a member of a union? If so, which one(s)?',


### PR DESCRIPTION
Also use foundation-sites "Typescaling". Where have you been all my
life? No more skipping heading levels for me.

https://get.foundation/sites/docs/typography-helpers.html#typescale