### PR TITLE
Sub Mailchimp address linebreaks with br

### DIFF
--- a/app/models/mailing_list_subscriber.rb
+++ b/app/models/mailing_list_subscriber.rb
@@ -18,7 +18,7 @@ class MailingListSubscriber
       merge_fields: {
         FNAME: member.first_name,
         LNAME: member.last_name,
-        ADDRESS: member.home_address,
+        ADDRESS: member.home_address.gsub("\n", "<br />"), # MC requires BR to preserve line breaks
         PHONE: member.phone_number,
         EMPNAME: member.employer,
         EMPADDRESS: member.work_address,


### PR DESCRIPTION
Requires an ADDRESS field on Mailchimp with a type of `text`, *not*
`address`. Delete and re-create there.

A Mailchimp ADDRESS field with a type of `address` has a schema that
fails validation without addr1, city, state, zip:

https://us1.api.mailchimp.com/schema/3.0/Lists/Members/MergeField.json