### PR TITLE
Make reached_step? errors better

### DIFF
--- a/app/models/membership_application/steps.rb
+++ b/app/models/membership_application/steps.rb
@@ -20,7 +20,7 @@ class MembershipApplication
 
     def index_of(step)
       @index_of ||= step_names.each_with_index.map { |name, index| [name, index] }.to_h
-      @index_of[step]
+      @index_of.fetch(step)
     end
 
     def reached_step?(application_step, step)

--- a/spec/models/membership_application/steps_spec.rb
+++ b/spec/models/membership_application/steps_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MembershipApplication::Steps do
       aggregate_failures do
         expect(steps.index_of('about-you')).to eql(0)
         expect(steps.index_of('contact-details')).to eql(1)
-        expect(steps.index_of('non-existent')).to be_nil
+        expect { steps.index_of('non-existent') }.to raise_error(KeyError)
       end
     end
   end


### PR DESCRIPTION
`NoMethodError: undefined method>=' for nil:NilClass'` is what we see
when we hit a step that isn't in the list.

Saw this recently as part of dropped cart, and was because
`index_of('work-and-pay')` was returning `nil` (we renamed that step).

Raise a `KeyError` instead with `#fetch`, then we'd see:

`KeyError (key not found: "work-and-pay")`