### PR TITLE
Make email confirmation explicit

### DIFF
--- a/app/views/membership_applications/steps/contact-details.html.erb
+++ b/app/views/membership_applications/steps/contact-details.html.erb
@@ -2,8 +2,8 @@
 
 <%= form_for @membership_application, url: wizard_path do |f| %>
   <fieldset>
-    <%= f.label :email %>
-    <%= help_for :email %>
+    <%= f.label :confirm_email %>
+    <%= help_for :confirm_email %>
     <%= form_field_errors f, :email %>
     <%= f.text_field :email %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
     label:
       membership_application:
         email: "Email address"
+        confirm_email: "Make sure your email is right"
         job_title: 'Your job title or grade'
         department_section: 'Your department or section'
         employer: 'Your employer'
@@ -75,6 +76,7 @@ en:
         date_of_birth: 'e.g. 19/08/1989'
         department_section: "Leave blank if you're not sure"
         email: 'A personal email is better'
+        confirm_email: 'If this email address looks wrong, you can change it now'
         home_address: 'include your Eircode, if known'
         work_address: 'include your Eircode, if known'
         phone_number: 'Your mobile number is best'


### PR DESCRIPTION
It's still pre-filled; don't give people a typing test. But
do use language like "make sure" to get people to check things
over.