### PR TITLE
Avoid initializer autoload deprecation

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,7 @@
 # Be sure to restart your server when you modify this file.
+require 'application_record'
+require 'membership_application'
+require 'membership_application/steps'
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [:password] + MembershipApplication::Steps::FILTER_PARAMS


### PR DESCRIPTION
```
DEPRECATION WARNING: Initialization autoloaded the constants ApplicationRecord, MembershipApplication, and MembershipApplication::Steps.

Being able to do this is deprecated. Autoloading during initialization is going to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during initialization does not run again. So, if you reload ApplicationRecord, for example, the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.
 ```