### PR TITLE
No dropped cart email if signed application exists

### DIFF
--- a/lib/forsa/dropped_cart.rb
+++ b/lib/forsa/dropped_cart.rb
@@ -6,10 +6,6 @@ module Forsa
       @logger = logger
     end
 
-    def dropped_applications
-      @dropped_applications ||= MembershipApplication.dropped_cart
-    end
-
     def subscribe_dropped_applications
       logger.info "Beginning Forsa::DroppedCart#subscribe_dropped_applications "\
                   "for #{dropped_applications.count} dropped applications"
@@ -17,17 +13,33 @@ module Forsa
       dropped_applications.each do |application|
         logger.info "Processing dropped application #{application.id}"
 
-        begin
-          DroppedCartMailingListSubscriber.new(application).subscribe! if application.dropped_cart_processed_at.nil?
-          application.update(dropped_cart_mailchimp_status: '200')
-        rescue Gibbon::MailChimpError => e
-          logger.error(e)
-          application.update(dropped_cart_mailchimp_status: e.status_code)
-        end
+        # if the user closed their tab, dropping an application,
+        # but later completed a fresh one for the same email, don't
+        # pester them, as they assume they haven't signed up and dutifully
+        # complete a second application to make sure
+        attempt_subscription(application) unless completed_application_exists?(application.email)
         application.touch(:dropped_cart_processed_at)
       end
 
       logger.info "Finished Forsa::DroppedCart#subscribe_dropped_applications"
+    end
+
+    private
+
+    def dropped_applications
+      @dropped_applications ||= MembershipApplication.dropped_cart
+    end
+
+    def completed_application_exists?(email)
+      MembershipApplication.signed.where(email: email).exists?
+    end
+
+    def attempt_subscription(application)
+      DroppedCartMailingListSubscriber.new(application).subscribe! if application.dropped_cart_processed_at.nil?
+      application.update(dropped_cart_mailchimp_status: '200')
+    rescue Gibbon::MailChimpError => e
+      logger.error(e)
+      application.update(dropped_cart_mailchimp_status: e.status_code)
     end
   end
 end


### PR DESCRIPTION
When a user has half-completed an application, then abandoned it, but
then come back and completed a fresh application, don't subscribe them
to the dropped cart list. We hypothesise that our "duplicate"
applications result from people being instructed to finish their
application when one is already complete.